### PR TITLE
uses correct form for mod and DC

### DIFF
--- a/src/components/SpellPage.js
+++ b/src/components/SpellPage.js
@@ -58,7 +58,7 @@ const SpellPage = ({
       <HeaderBar>
         <Column>
           <h2>{ level } Level Spells</h2>
-          <p><b>Modifier:</b> { mod } | <b>DC:</b> { 10 + +mod }</p>
+          <p><b>Modifier:</b> { mod } | <b>DC:</b> { 8 + +mod }</p>
         </Column>
         <Spacer />
         <ActionBar>

--- a/src/containers/CharacterSheet.js
+++ b/src/containers/CharacterSheet.js
@@ -147,7 +147,7 @@ const CharacterSheet = ({ characterData }) => {
             mod={ calculateModifier(
               character[
               classInfo.spellcasting_ability.toLowerCase().substring(0, 3)
-              ]
+              ], character.proBonus
             ) }
           />
         ) }


### PR DESCRIPTION
Spellcasting fix: Adds proficiency bonus to modifier and uses `8` as the base DC

fixes #29